### PR TITLE
Pin next-auth version to the latest working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "vue-router": "^4.2.5"
   },
   "dependencies": {
-    "next-auth": "^4.21.1"
+    "next-auth": "~4.22.5"
   }
 }


### PR DESCRIPTION
Newer versions of next-auth library are buggy and don't work. This pull request pins the library to the latest working version.

Source: https://github.com/sidebase/nuxt-auth/issues/514